### PR TITLE
LIBFCREPO-149. Cache self-signed HTTPS cert in dist/ssl.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.vagrant/
 /dist/*.tar.gz
+/dist/ssl/

--- a/scripts/https-cert.sh
+++ b/scripts/https-cert.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
-# SSL Certificate (self-signed)
-mkdir -p /apps/ssl/{key,csr,cert,cnf}
+CACHED_SSL_CONF=/apps/dist/ssl
 
-KEY=/apps/ssl/key/iiiflocal.key
-CSR=/apps/ssl/csr/iiiflocal.csr
-CRT=/apps/ssl/cert/iiiflocal.crt
-CNF=/apps/ssl/cnf/iiiflocal.cnf
+if [ -e "$CACHED_SSL_CONF" ]; then
+    echo "Using HTTPS SSL configuration cached in dist/ssl"
+    cp -rp /apps/dist/ssl /apps
+else
+    # SSL Certificate (self-signed)
+    mkdir -p /apps/ssl/{key,csr,cert,cnf}
 
-cat > "$CNF" <<END
+    KEY=/apps/ssl/key/iiiflocal.key
+    CSR=/apps/ssl/csr/iiiflocal.csr
+    CRT=/apps/ssl/cert/iiiflocal.crt
+    CNF=/apps/ssl/cnf/iiiflocal.cnf
+
+    cat > "$CNF" <<END
 [ req ]
 prompt                  = no
 distinguished_name      = iiiflocal_dn
@@ -31,12 +37,16 @@ IP.1 = 192.168.40.13
 IP.2 = 127.0.0.1
 END
 
-# Generate private key 
-openssl genrsa -out "$KEY" 2048
+    # Generate private key 
+    openssl genrsa -out "$KEY" 2048
 
-# Generate CSR 
-openssl req -new -key "$KEY" -out "$CSR" -config "$CNF"
+    # Generate CSR 
+    openssl req -new -key "$KEY" -out "$CSR" -config "$CNF"
 
-# Generate self-signed cert
-openssl x509 -req -days 365 -in "$CSR" -signkey "$KEY" -out "$CRT" \
-    -extensions v3_req -extfile "$CNF"
+    # Generate self-signed cert
+    openssl x509 -req -days 365 -in "$CSR" -signkey "$KEY" -out "$CRT" \
+        -extensions v3_req -extfile "$CNF"
+
+    # cache the SSL cert info for the next run of Vagrant
+    cp -rp /apps/ssl /apps/dist
+fi


### PR DESCRIPTION
Allows for the same self-signed certificate to be used across multiple creations and deletions of the Vagrant.

https://issues.umd.edu/browse/LIBFCREPO-149
