### PR TITLE
LIBIIIF-10. Update to mirador-static 1.1.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,13 @@ images from Fedora 4
 
 ## Prerequisites
 
-1. Clone the `develop` branch of [iiif-env] into 
-   `/apps/git/iiif-env`:
-   
-   ```
-   cd /apps/git
-   git clone -b develop git@bitbucket.org:umd-lib/iiif-env.git
-   ```
-   
-2. To serve images from Fedora 4, clone and run the
+1. Clone [iiif-env] into `/apps/git/iiif-env`.
+2. Clone [pcdm-manifests] into `/apps/git/pcdm-manifests`.
+3. Clone [mirador-static] into `/apps/git/mirador-static`.
+4. To serve images from Fedora 4, clone and run the
    [fcrepo-vagrant]. The HTTP resolver in Loris is currently
    configured to serve images from
-   <https://fcrepolocal/fcrepo/rest/{id}>
+   <https://fcrepolocal/fcrepo/rest/{id}>.
    
 ## Setup
 
@@ -33,14 +28,6 @@ images from Fedora 4
    vagrant up
    ```
 
-3. Start Apache:
-
-   ```
-   vagrant ssh
-   cd /apps/iiif/apache
-   ./control start
-   ```
-
 4. Add the server to your workstation's hosts file:
 
    ```
@@ -52,6 +39,8 @@ The server should now be up and running at <https://iiiflocal>
 Loris should be running at <https://iiiflocal/images/>
 
 [iiif-env]: https://bitbucket.org/umd-lib/iiif-env
+[pcdm-manifests]: https://github.com/umd-lib/pcdm-manifests
+[mirador-static]: https://github.com/umd-lib/mirador-static
 [fcrepo-vagrant]: https://github.com/umd-lib/fcrepo-vagrant
 
 ## License

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "dist", "/apps/dist"
   config.vm.synced_folder "/apps/git/iiif-env", "/apps/git/iiif-env"
   config.vm.synced_folder "/apps/git/pcdm-manifests", "/apps/iiif/pcdm-manifests"
+  config.vm.synced_folder "/apps/git/mirador-static", "/apps/git/mirador-static"
 
   # system packages and hosts file
   config.vm.provision "puppet"
@@ -60,7 +61,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: 'scripts/https-cert.sh'
 
   # install Mirador viewer
-  config.vm.provision 'shell', path: 'scripts/mirador.sh'
+  config.vm.provision 'shell', path: 'scripts/mirador.sh', privileged: false
 
   # server-specific configuration files
   config.vm.provision "file", source: 'files/env', destination: '/apps/iiif/config/env'

--- a/scripts/mirador.sh
+++ b/scripts/mirador.sh
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-SERVICE_USER_GROUP=vagrant:vagrant
+MIRADOR_VERSION=1.1.0
+MIRADOR_BRANCH=1.1.0
 
-MIRADOR_VERSION=1.0
-MIRADOR_TGZ=/apps/dist/mirador-static-${MIRADOR_VERSION}.tar.gz
-# look for a cached tarball
-if [ ! -e "$MIRADOR_TGZ" ]; then
-    MIRADOR_PKG_URL=https://github.com/umd-lib/mirador-static/archive/v${MIRADOR_VERSION}.tar.gz
-    curl -Lso "$MIRADOR_TGZ" "$MIRADOR_PKG_URL"
-fi
-tar xvzf "$MIRADOR_TGZ" --directory /apps
-ln -s /apps/mirador-static-${MIRADOR_VERSION} /apps/iiif/apache/html/viewer
+mkdir -p /apps/iiif/mirador-static
+cd /apps/iiif/mirador-static
+git clone file:///apps/git/mirador-static "$MIRADOR_VERSION"
+cd "$MIRADOR_VERSION"
+git checkout "$MIRADOR_BRANCH"
 
-chown -R "$SERVICE_USER_GROUP" /apps/mirador-static-${MIRADOR_VERSION}
+ln -sf /apps/iiif/mirador-static/${MIRADOR_VERSION} /apps/iiif/apache/html/viewer/${MIRADOR_VERSION}

--- a/scripts/nodejs.sh
+++ b/scripts/nodejs.sh
@@ -1,4 +1,9 @@
 #/bin/bash
 
+curl --silent --location https://rpm.nodesource.com/setup_6.x | sudo bash -
+
+wget http://springdale.math.ias.edu/data/puias/unsupported/7/x86_64/http-parser-2.7.1-3.sdl7.x86_64.rpm
+rpm -Uvh http-parser-2.7.1-3.sdl7.x86_64.rpm
+
 # install NodeJS to support Rails asset pipeline
-yum install -y --enablerepo=epel nodejs npm
+yum install -y --enablerepo=epel nodejs-6.11.1-1.el7 npm


### PR DESCRIPTION
Also updated README, and added explicit versions for the NodeJS and npm dependencies.

https://issues.umd.edu/browse/LIBIIIF-10