### PR TITLE
LIBIIIF-27. Point fedora2 HTTP resolver to fedoradev.

### DIFF
--- a/files/env
+++ b/files/env
@@ -5,3 +5,4 @@ export SERVICE_GROUP=vagrant
 export SSL_CERT_NAME=iiiflocal
 export SSL_KEY_NAME=iiiflocal
 export FCREPO_SERVER=fcrepolocal
+export FEDORA_SERVER=fedoradev.lib.umd.edu


### PR DESCRIPTION
This is currently the best default, since we do not have a Vagrant environment for Fedora 2. Requires https://bitbucket.org/umd-lib/iiif-env/pull-requests/14 to be merged in first.

https://issues.umd.edu/browse/LIBIIIF-27