### PR TITLE
LIBIIIF-31. Install mod_passenger from source tarball.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,8 +47,6 @@ Vagrant.configure("2") do |config|
   # install Loris runtime
   config.vm.provision "shell", path: 'scripts/loris-install.sh', privileged: false
 
-  # Passenger
-  config.vm.provision "shell", path: "scripts/passenger.sh", privileged: true
   # Nodejs for rails asset pipeline
   config.vm.provision "shell", path: "scripts/nodejs.sh", privileged: true
   # pcdm-manifests app
@@ -59,6 +57,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", path: 'scripts/apache.sh'
   # HTTPS certificate for Apache
   config.vm.provision "shell", path: 'scripts/https-cert.sh'
+  # Passenger
+  config.vm.provision "shell", path: "scripts/passenger.sh", privileged: true
 
   # install Mirador viewer
   config.vm.provision 'shell', path: 'scripts/mirador.sh', privileged: false

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -48,6 +48,27 @@ package { "git":
   ensure => present,
 }
 
+
+# Passenger prereqs
+package { "epel-release":
+  ensure => present,
+}
+package { "ruby-devel":
+  ensure  => present,
+  require => Package["epel-release"],
+}
+package { "rubygem-rake":
+  ensure  => present,
+  require => Package["epel-release"],
+}
+package { "rubygem-rack":
+  ensure  => present,
+  require => Package["epel-release"],
+}
+package { "libcurl-devel":
+  ensure => present,
+}
+
 host { 'fcrepolocal':
   ip => '192.168.40.10',
 }

--- a/scripts/passenger.sh
+++ b/scripts/passenger.sh
@@ -1,22 +1,7 @@
 #!/bin/bash
 
-# https://www.phusionpassenger.com/library/install/apache/install/oss/tarball/
-# because Phusion's yum repo doesn't currently work with CentOS 7's curl
+# https://www.phusionpassenger.com/library/walkthroughs/deploy/ruby/ownserver/apache/oss/el7/install_passenger.html
 
-PASSENGER_VERSION=5.1.8
-PASSENGER_TGZ=/apps/dist/passenger-release-$PASSENGER_VERSION.tar.gz
-if [ ! -e "$PASSENGER_TGZ" ]; then
-    PASSENGER_PKG_URL=https://github.com/phusion/passenger/archive/release-${PASSENGER_VERSION}.tar.gz
-    curl -Lso "$PASSENGER_TGZ" "$PASSENGER_PKG_URL"
-fi
-tar xvzf "$PASSENGER_TGZ" --directory /apps
-
-PASSENGER_ROOT=/apps/passenger-release-$PASSENGER_VERSION
-
-$PASSENGER_ROOT/bin/passenger-install-apache2-module
-
-cat > /etc/profile.d/passenger.sh <<END
-export PATH=$PASSENGER_ROOT/bin:\$PATH
-END
-
-cp $PASSENGER_ROOT/buildout/apache2/mod_passenger.so /apps/iiif/apache/modules/
+yum install -y httpd epel-release pygpgme curl nss
+REPO_URL=https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
+curl --fail -sSLo /etc/yum.repos.d/passenger.repo "$REPO_URL" && yum install -y mod_passenger

--- a/scripts/passenger.sh
+++ b/scripts/passenger.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
 
-# https://www.phusionpassenger.com/library/walkthroughs/deploy/ruby/ownserver/apache/oss/el7/install_passenger.html
+# https://www.phusionpassenger.com/library/install/apache/install/oss/tarball/
+# because Phusion's yum repo doesn't currently work with CentOS 7's curl
 
-yum install -y httpd epel-release pygpgme curl
-curl --fail -sSLo /etc/yum.repos.d/passenger.repo \
-  https://oss-binaries.phusionpassenger.com/yum/definitions/el-passenger.repo
-yum install -y mod_passenger
+PASSENGER_VERSION=5.1.8
+PASSENGER_TGZ=/apps/dist/passenger-release-$PASSENGER_VERSION.tar.gz
+if [ ! -e "$PASSENGER_TGZ" ]; then
+    PASSENGER_PKG_URL=https://github.com/phusion/passenger/archive/release-${PASSENGER_VERSION}.tar.gz
+    curl -Lso "$PASSENGER_TGZ" "$PASSENGER_PKG_URL"
+fi
+tar xvzf "$PASSENGER_TGZ" --directory /apps
+
+PASSENGER_ROOT=/apps/passenger-release-$PASSENGER_VERSION
+
+$PASSENGER_ROOT/bin/passenger-install-apache2-module
+
+cat > /etc/profile.d/passenger.sh <<END
+export PATH=$PASSENGER_ROOT/bin:\$PATH
+END
+
+cp $PASSENGER_ROOT/buildout/apache2/mod_passenger.so /apps/iiif/apache/modules/


### PR DESCRIPTION
Currently, we are unable to install the mod_passenger package from the Phusion Passenger yum repository due to possible configuration problems on Phusion's servers. In order to render this Vagrant functional again, we have switched to installing Passenger from the source tarball available from GitHub.

https://issues.umd.edu/browse/LIBIIIF-31