### PR TITLE
LIBIIIF-49. Ensure bc is installed.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -47,6 +47,9 @@ package { "mod_ssl":
 package { "git":
   ensure => present,
 }
+package { "bc":
+  ensure => present,
+}
 
 
 # Passenger prereqs


### PR DESCRIPTION
It is used in the Loris cache cleanup script, to translate from human-readable sizes to exact bytes.

https://issues.umd.edu/browse/LIBIIIF-49