### PR TITLE
LIBIIIF-60. Install Git 2.x and use newer TLS to connect to GitHub.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -2,6 +2,12 @@ Package {
   allow_virtual => false,
 }
 
+exec { "IUS release package":
+  command => "/usr/bin/rpm -i https://centos7.iuscommunity.org/ius-release.rpm",
+  unless  => "/usr/bin/rpm -q ius-release",
+  require => Package["epel-release"],
+}
+
 # development and troubleshooting tools
 package { "vim-enhanced":
   ensure => present,
@@ -44,10 +50,17 @@ package { "libtiff-devel":
 package { "mod_ssl":
   ensure => present,
 }
-package { "git":
-  ensure => present,
+# need a newer version of Git; use the IUS community repo
+# see https://ius.io/
+package { "git2u":
+  ensure  => present,
+  require => Exec["IUS release package"],
 }
 package { "bc":
+  ensure => present,
+}
+# cloning from GitHub over HTTPS requires updating NSS
+package { "nss":
   ensure => present,
 }
 

--- a/scripts/python.sh
+++ b/scripts/python.sh
@@ -2,6 +2,9 @@
 
 PYTHON_VERSION=2.7.12
 
+# GitHub requires newer TLS versions for HTTPS cloning
+# see https://github.com/blog/2507-weak-cryptographic-standards-removed
+export GIT_SSL_VERSION=tlsv1
 # install pyenv (https://github.com/pyenv/pyenv-installer)
 curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 


### PR DESCRIPTION
Solves the problem of pyenv not getting installed.

https://issues.umd.edu/browse/LIBIIIF-60