### PR TITLE
LIBIIIF-72. Corrected SSL-related provisoning problems.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -2,10 +2,16 @@ Package {
   allow_virtual => false,
 }
 
+# make sure we have the latest CA certs
+# needed to install the IUS release package
+package { "ca-certificates":
+  ensure => latest,
+}
+
 exec { "IUS release package":
   command => "/usr/bin/rpm -i https://centos7.iuscommunity.org/ius-release.rpm",
   unless  => "/usr/bin/rpm -q ius-release",
-  require => Package["epel-release"],
+  require => [ Package["ca-certificates"], Package["epel-release"] ],
 }
 
 # development and troubleshooting tools

--- a/scripts/python.sh
+++ b/scripts/python.sh
@@ -20,4 +20,7 @@ END
 
 # install Python
 source $HOME/.pyenv.bash_profile
+# force python-build to use TLSv1 when downloading
+export PYTHON_BUILD_HTTP_CLIENT=curl
+export PYTHON_BUILD_CURL_OPTS=--tlsv1
 pyenv install "$PYTHON_VERSION"


### PR DESCRIPTION
* Install the latest ca-certificates package
* Force pyenv install to use curl with the --tlsv1 switch

https://issues.umd.edu/browse/LIBIIIF-72